### PR TITLE
GIT-0000:  Add git Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Summary: ✍️
+Provide a general description of the code changes in your pull request.
+
+### Issue(s): 🎟️
+<!-- Example -->
+- [GIT-ISSUE](https://github.com/Elaniobro/git-files/issues)
+
+<!-- Optional
+### Visual: 🔍
+_include screengrabs of before/after_
+#### Before:
+
+#### After:
+
+<!-- Optional
+### Reference(s): 📖
+-->

--- a/git-templates/PULL_REQUEST_TEMPLATE.md
+++ b/git-templates/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Summary: ✍️
+Provide a general description of the code changes in your pull request.
+
+### Issue(s): 🎟️
+<!-- Example -->
+- [GIT-ISSUE](https://github.com/Elaniobro/git-files/issues)
+
+<!-- Optional -->
+### Visual: 🔍
+_include screengrabs of before/after_
+#### Before:
+
+#### After:
+
+<!-- Optional -->
+### Reference(s): 📖
+


### PR DESCRIPTION
### Summary: ✍️
Adds the `PULL_REQUEST_TEMPLATE.md` file as both documentation and a template for this repo.

### Issue(s): 🎟️
<!-- Example -->
- [GIT-ISSUE](https://github.com/Elaniobro/git-files/issues)

<!-- Optional -->
### Visual: 🔍
_include screengrabs of before/after_
#### Before:
<img width="1025" alt="screen shot 2019-01-17 at 4 19 26 pm" src="https://user-images.githubusercontent.com/710847/51349550-b9117100-1a73-11e9-8de0-e8ef3b1c9af7.png">

#### After:
<img width="1084" alt="screen shot 2019-01-17 at 4 19 43 pm" src="https://user-images.githubusercontent.com/710847/51349560-bdd62500-1a73-11e9-86ae-72486f14644d.png">

<!-- Optional -->
### Reference(s): 📖
* [Creating a PR Template for your repo](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/)