### PR TITLE
HOOK-0000:  Add commit-msg hook

### DIFF
--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,101 @@
+#!/bin/bash
+# author: Elan Trybuch
+# email: eitrybuch@gmail.com
+# git: elaniobro
+# twitter: elaniobro
+# instagram: elaniobro
+# license: MIT
+exec < /dev/tty
+
+# Clear the screen.
+clear
+
+COMMIT_FILE=$1
+COMMIT_MSG=$(cat $1)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+JIRA_ID=$(echo "$CURRENT_BRANCH" | grep -Eo "[A-Z0-9]{1,10}-?[A-Z0-9]+-\d+")
+SEPARATOR=$(echo ": ")
+
+run_generic_git_cmds() {
+    echo -e "The following commands where ran to follow best practices:"
+    echo -e "\033[32mgit branch -m $CURRENT_BRANCH HBC-0000-$CURRENT_BRANCH"
+    echo -e "git commit -m \"HBC-0000$SEPARATOR $COMMIT_MSG\"\033[0m"
+
+    eval "git branch -m $CURRENT_BRANCH HBC-0000-$CURRENT_BRANCH"
+    eval "git commit -m \"HBC-0000$SEPARATOR $COMMIT_MSG\"" > $COMMIT_FILE
+    exit 1
+}
+
+# Git commands to run with the user entered jira issue prepended
+run_jira_git_cmds() {
+    echo -e "The following commands where ran to follow best practices:"
+    echo -e "\033[32mgit branch -m $CURRENT_BRANCH $ANSWER-$CURRENT_BRANCH"
+    echo -e "git commit -m \"$JIRA_ID$SEPARATOR $COMMIT_MSG\"\033[0m"
+
+    eval "git branch -m $CURRENT_BRANCH $ANSWER-$CURRENT_BRANCH"
+    eval "git commit -m \"$JIRA_ID$SEPARATOR $COMMIT_MSG\"" > $COMMIT_FILE
+    exit 1
+}
+
+# Clears the user input
+clean_input() {
+    while read -r -t 0; do read -r; done
+}
+
+# if/else to verify if a jira id exists in the git branch a user is trying to commit to.
+if [ ! -z "$JIRA_ID" ];
+then
+    echo "$JIRA_ID$SEPARATOR $COMMIT_MSG" > $COMMIT_FILE
+    echo -e "The JIRA ID: ['\033[1m\033[38;5;147m$JIRA_ID\033[0m'] was found in the branch naming and matched the jira id in the current branch name."
+    echo -e "['\033[1m\033[38;5;147m$JIRA_ID\033[0m'] was prepended to commit message. (Use --no-verify to skip)"
+else
+    # Have some fun
+    echo -e "\033[38;5;202m  ██╗  ██╗██████╗  ██████╗    ████████╗███████╗ ██████╗██╗  ██╗"
+    echo -e "  ██║  ██║██╔══██╗██╔════╝    ╚══██╔══╝██╔════╝██╔════╝██║  ██║"
+    echo -e "  ███████║██████╔╝██║            ██║   █████╗  ██║     ███████║"
+    echo -e "  ██╔══██║██╔══██╗██║            ██║   ██╔══╝  ██║     ██╔══██║"
+    echo -e "  ██║  ██║██████╔╝╚██████╗       ██║   ███████╗╚██████╗██║  ██║"
+    echo -e "  ╚═╝  ╚═╝╚═════╝  ╚═════╝       ╚═╝   ╚══════╝ ╚═════╝╚═╝  ╚═╝\033[0m"
+    echo ""
+    echo ""
+   # Alert user that their commit is breaking the HBC best practice standards
+    echo -e "\033[5m🚨🚨🚨🚨\033[25m 👮 \033[31mCOMMIT POLICE\033[0m 👮 \033[5m🚨🚨🚨🚨\033[25m"
+    echo -e "\033[33mYour branch does not follow naming conventions"
+    echo ""
+    echo ""
+    # No jira id found, proceed to the prompt
+    echo -e "\033[33mAre you currently workin on a jira issue?\033[0m"
+    PS3="Enter 1 or 2: "
+    #options=("Yes, I am." "No, work is nessesary, but not currently tracked.")
+    select options in Yes No
+    do
+        case $options in
+            "Yes")
+                break
+                ;;
+            "No")
+            run_generic_git_cmds
+            break
+            ;;
+        esac
+    done
+
+    # user prompt that awaits an input
+    while  read -p "Please enter the jira issue number: " ANSWER; do
+
+        # jira id regex check
+        regexp="([A-Z0-9]{1,10}-?[A-Z0-9]+-)"
+        if [[ $ANSWER =~ $regexp ]];
+        then
+            echo "You entered a valid jira issue"
+            run_jira_git_cmds
+            break
+        else
+            # TODO: FIgure out logic to send fail back to prompt and not store the ANSWER
+            echo -e "\033[31m$ANSWER \033[0m is not an accepted format for a jira issue"
+            echo -e "Please use the following format: \033[32mJIRA-1234\033[0m"
+        fi
+    done
+
+    exit 0
+fi


### PR DESCRIPTION
### Summary: ✍️
Adds the `commit-msg` .git hook, which prevents a user from not following best practice. This hook uses a regex to scan the branch from which you are trying to commit, for a Jira/Git/Asana/etc.. ticket number. 

If none exits, the user is guided through a simple prompt to add the Issue number and or default to a pre-defined `tech-debt` Issue number. 

After the prompt, the git branch that the user is on, is moved to the correct branch name, which follows best practice, and the commits are applied for them.

<!-- Optional -->
### Visual: 🔍
_include screengrabs of before/after_
#### Before:

#### After:
##### Option No.1
![option-1](https://user-images.githubusercontent.com/710847/51350777-16f38800-1a77-11e9-9995-f6d892d8f30c.gif)
 
##### Option No.2
![option2](https://user-images.githubusercontent.com/710847/51350781-1955e200-1a77-11e9-9c3b-f9f6de8c315c.gif)

<!-- Optional -->
### Reference(s): 📖
* [git hooks](https://githooks.com)